### PR TITLE
Reuse array methods as much as possible

### DIFF
--- a/packages/record-tuple-polyfill/src/record.js
+++ b/packages/record-tuple-polyfill/src/record.js
@@ -21,6 +21,7 @@ import {
     validateProperty,
     isRecord,
     markRecord,
+    define,
 } from "./utils";
 
 function createFreshRecordFromProperties(properties) {
@@ -61,16 +62,23 @@ export function Record(value) {
 // ensure that Record.name is "Record" even if this
 // source is aggressively minified or bundled.
 if (Record.name !== "Record") {
-    Object.defineProperty(Record, "name", { value: "Record" });
+    Object.defineProperty(Record, "name", {
+        value: "Record",
+        configurable: true,
+    });
 }
+
+define(Record, {
+    isRecord,
+    fromEntries(iterator) {
+        return createRecordFromObject(objectFromEntries(iterator));
+    },
+});
+
 Record.prototype = Object.create(null);
-Record.prototype.constructor = Record;
-Record.prototype.toString = function toString() {
-    return "[record Record]";
-};
-
-Record.isRecord = isRecord;
-
-Record.fromEntries = function fromEntries(iterator) {
-    return createRecordFromObject(objectFromEntries(iterator));
-};
+define(Record.prototype, {
+    constructor: Record,
+    toString() {
+        return "[record Record]";
+    },
+});

--- a/packages/record-tuple-polyfill/src/record.test.js
+++ b/packages/record-tuple-polyfill/src/record.test.js
@@ -131,3 +131,34 @@ test("Records work with Object.values", () => {
 test("Record.prototype.toString", () => {
     expect(Record({ a: 1 }).toString()).toEqual("[record Record]");
 });
+
+describe("correct descriptors", () => {
+    const desc = Object.getOwnPropertyDescriptor;
+
+    test.each(["isRecord", "fromEntries"])("Record.%s", name => {
+        expect(desc(Record, name)).toEqual({
+            writable: true,
+            enumerable: false,
+            configurable: true,
+            value: expect.any(Function),
+        });
+    });
+
+    test("Record.name", () => {
+        expect(desc(Record, "name")).toEqual({
+            writable: false,
+            enumerable: false,
+            configurable: true,
+            value: "Record",
+        });
+    });
+
+    test("Record.length", () => {
+        expect(desc(Record, "name")).toEqual({
+            writable: false,
+            enumerable: false,
+            configurable: true,
+            value: 0,
+        });
+    });
+});

--- a/packages/record-tuple-polyfill/src/record.test.js
+++ b/packages/record-tuple-polyfill/src/record.test.js
@@ -154,11 +154,11 @@ describe("correct descriptors", () => {
     });
 
     test("Record.length", () => {
-        expect(desc(Record, "name")).toEqual({
+        expect(desc(Record, "length")).toEqual({
             writable: false,
             enumerable: false,
             configurable: true,
-            value: 0,
+            value: 1,
         });
     });
 });

--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -191,7 +191,7 @@ define(Tuple.prototype, {
     some: Array.prototype.some,
 
     values() {
-        return this[Symbol.iterator]();
+        return Array.prototype.values.call(this);
     },
 
     with(index, value) {
@@ -205,21 +205,10 @@ define(Tuple.prototype, {
 
     toString: Array.prototype.toString,
     toLocaleString: Array.prototype.toLocaleString,
+});
 
-    [Symbol.iterator]() {
-        let index = 0;
-        return {
-            next: () => {
-                if (index < this.length) {
-                    const result = { value: this[index], done: false };
-                    index++;
-                    return result;
-                } else {
-                    return { value: undefined, done: true };
-                }
-            },
-        };
-    },
+define(Tuple.prototype, {
+    [Symbol.iterator]: Tuple.prototype.values,
 });
 
 function fromArray(obj, name, ...args) {

--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -153,21 +153,13 @@ define(Tuple.prototype, {
         );
     },
 
-    includes(valueToFind, fromIndex) {
-        return Array.from(this).includes(valueToFind, fromIndex);
-    },
+    includes: Array.prototype.includes,
 
-    indexOf(valueToFind, fromIndex) {
-        return Array.from(this).indexOf(valueToFind, fromIndex);
-    },
+    indexOf: Array.prototype.indexOf,
 
-    join(separator) {
-        return Array.from(this).join(separator);
-    },
+    join: Array.prototype.join,
 
-    lastIndexOf(valueToFind, fromIndex) {
-        return Array.from(this).lastIndexOf(valueToFind, fromIndex);
-    },
+    lastIndexOf: Array.prototype.lastIndexOf,
 
     sliced(start, end) {
         return createTupleFromIterableObject(
@@ -183,12 +175,7 @@ define(Tuple.prototype, {
         )[Symbol.iterator]();
     },
 
-    every(callback, thisArg) {
-        return Array.from(this).every(
-            wrapTupleCallback(this, callback),
-            thisArg,
-        );
-    },
+    every: Array.prototype.every,
 
     filter(callback, thisArg) {
         return createTupleFromIterableObject(
@@ -196,26 +183,11 @@ define(Tuple.prototype, {
         );
     },
 
-    find(callback, thisArg) {
-        return Array.from(this).find(
-            wrapTupleCallback(this, callback),
-            thisArg,
-        );
-    },
+    find: Array.prototype.find,
 
-    findIndex(callback, thisArg) {
-        return Array.from(this).findIndex(
-            wrapTupleCallback(this, callback),
-            thisArg,
-        );
-    },
+    findIndex: Array.prototype.findIndex,
 
-    forEach(callback, thisArg) {
-        return Array.from(this).forEach(
-            wrapTupleCallback(this, callback),
-            thisArg,
-        );
-    },
+    forEach: Array.prototype.forEach,
 
     keys() {
         return createTupleFromIterableObject(Array.from(this).keys())[
@@ -229,26 +201,11 @@ define(Tuple.prototype, {
         );
     },
 
-    reduce(callback, initialValue) {
-        return Array.from(this).reduce(
-            wrapTupleReduceCallback(this, callback),
-            initialValue,
-        );
-    },
+    reduce: Array.prototype.reduce,
 
-    reduceRight(callback, initialValue) {
-        return Array.from(this).reduceRight(
-            wrapTupleReduceCallback(this, callback),
-            initialValue,
-        );
-    },
+    reduceRight: Array.prototype.reduceRight,
 
-    some(callback, thisArg) {
-        return Array.from(this).some(
-            wrapTupleCallback(this, callback),
-            thisArg,
-        );
-    },
+    some: Array.prototype.some,
 
     values() {
         return this[Symbol.iterator]();

--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -181,7 +181,9 @@ define(Tuple.prototype, {
     },
 
     map(callback, thisArg) {
-        return fromArray(this, "map", callback, thisArg);
+        return fromArray(this, "map", function(value, key, tuple) {
+            return validateProperty(callback.call(thisArg, value, key, tuple));
+        });
     },
 
     reduce: Array.prototype.reduce,

--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -113,10 +113,7 @@ define(Tuple.prototype, {
 
     popped() {
         if (this.length <= 1) return Tuple();
-
-        return createTupleFromIterableObject(
-            Array.from(this).slice(0, this.length - 1),
-        );
+        return fromArray(this, "slice", 0, this.length - 1);
     },
 
     pushed(...vals) {
@@ -128,7 +125,7 @@ define(Tuple.prototype, {
     },
 
     shifted() {
-        return createTupleFromIterableObject(Array.from(this).slice(1));
+        return fromArray(this, "slice", 1);
     },
 
     unshifted(...vals) {
@@ -148,9 +145,7 @@ define(Tuple.prototype, {
     },
 
     concat(...values) {
-        return createTupleFromIterableObject(
-            Array.from(this).concat(...values),
-        );
+        return fromArray(this, "concat", ...values);
     },
 
     includes: Array.prototype.includes,
@@ -162,25 +157,17 @@ define(Tuple.prototype, {
     lastIndexOf: Array.prototype.lastIndexOf,
 
     sliced(start, end) {
-        return createTupleFromIterableObject(
-            Array.from(this).slice(start, end),
-        );
+        return fromArray(this, "slice", start, end);
     },
 
     entries() {
-        return createTupleFromIterableObject(
-            Array.from(this)
-                .entries()
-                .map(e => createTupleFromIterableObject(e)),
-        )[Symbol.iterator]();
+        return Array.prototype.entries.call(this);
     },
 
     every: Array.prototype.every,
 
     filter(callback, thisArg) {
-        return createTupleFromIterableObject(
-            Array.from(this).filter(wrapTupleCallback(this, callback), thisArg),
-        );
+        return fromArray(this, "filter", callback, thisArg);
     },
 
     find: Array.prototype.find,
@@ -190,15 +177,11 @@ define(Tuple.prototype, {
     forEach: Array.prototype.forEach,
 
     keys() {
-        return createTupleFromIterableObject(Array.from(this).keys())[
-            Symbol.iterator
-        ]();
+        return Array.prototype.keys.call(this);
     },
 
     map(callback, thisArg) {
-        return createTupleFromIterableObject(
-            Array.from(this).map(wrapTupleCallback(this, callback), thisArg),
-        );
+        return fromArray(this, "map", callback, thisArg);
     },
 
     reduce: Array.prototype.reduce,
@@ -239,13 +222,8 @@ define(Tuple.prototype, {
     },
 });
 
-function wrapTupleCallback(tuple, callback) {
-    return function(element, index) {
-        return callback.call(this, element, index, tuple);
-    };
-}
-function wrapTupleReduceCallback(tuple, callback) {
-    return function(accumulator, element, index) {
-        return callback.call(this, accumulator, element, index, tuple);
-    };
+function fromArray(obj, name, ...args) {
+    return createTupleFromIterableObject(
+        Array.prototype[name].apply(obj, args),
+    );
 }

--- a/packages/record-tuple-polyfill/src/tuple.test.js
+++ b/packages/record-tuple-polyfill/src/tuple.test.js
@@ -161,6 +161,12 @@ test("Tuple.prototype.toString", () => {
     expect(Tuple.prototype[Symbol.toStringTag]).toBe("Tuple");
 });
 
+test("Tuple.prototype.sliced", () => {
+    expect(Tuple().sliced(0, 2)).toBe(Tuple());
+    expect(Tuple(1, 2, 3, 4).sliced(1)).toBe(Tuple(2, 3, 4));
+    expect(Tuple(1, 2, 3, 4).sliced(-2)).toBe(Tuple(3, 4));
+    expect(Tuple(1, 2, 3, 4).sliced(1, 3)).toBe(Tuple(2, 3));
+});
 test("Tuple.prototype.popped", () => {
     expect(Tuple().popped()).toBe(Tuple());
     expect(Tuple(1).popped()).toBe(Tuple());

--- a/packages/record-tuple-polyfill/src/tuple.test.js
+++ b/packages/record-tuple-polyfill/src/tuple.test.js
@@ -178,6 +178,19 @@ test("Tuple.prototype.pushed", () => {
     expect(Tuple().pushed(1, 2, 3)).toBe(Tuple(1, 2, 3));
     expect(Tuple(1, 2, 3).pushed(4, 5, 6)).toBe(Tuple(1, 2, 3, 4, 5, 6));
 });
+describe("Tuple.prototype.map", () => {
+    test("validates the callback result after each iteration", () => {
+        const t = Tuple(1, 2, 3);
+        let i = 0;
+        expect(() =>
+            t.map(v => {
+                i++;
+                return { v };
+            }),
+        ).toThrow();
+        expect(i).toBe(1);
+    });
+});
 // TODO: Tuple prototype methods
 
 describe("correct descriptors", () => {

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -65,3 +65,14 @@ export function validateProperty(value) {
     }
     return value;
 }
+
+export function define(obj, props) {
+    for (const key of Reflect.ownKeys(props)) {
+        const { get, set, value } = Object.getOwnPropertyDescriptor(props, key);
+        let desc =
+            get || set
+                ? { get, set, configurable: true }
+                : { value, writable: true, configurable: true };
+        Object.defineProperty(obj, key, desc);
+    }
+}


### PR DESCRIPTION
- The first commit updates this polyfill to match the spec, using the existing array methods when they have the same behavior as the tuple methods
- The second commit cleans up a bit the delegation to the array methods where the behavior is different (they produce a tuple instead of an array)
- The third commit makes `[Symbol.iterator]` an alias to `.values`, as described in the spec
- The fourth commit fixes a bug with checks missing for the value returned by the `.map` callback, because it isn't checked by `Array.prototype.map`